### PR TITLE
Include notification category identifier in the app payload

### DIFF
--- a/app/Services/PushNotifications.php
+++ b/app/Services/PushNotifications.php
@@ -81,7 +81,8 @@ class PushNotifications
             ),
             'badge' => 0,
             'sound' => 'default',
-            'link_url' => "http://www.w3schools.com/w3css/w3css_colors.asp"
+            'link_url' => "http://www.w3schools.com/w3css/w3css_colors.asp",
+            'category' => "com.CodeBurrow.HotelApp.notifications.test"
         );
         ## notice : alert, badge, sound
 


### PR DESCRIPTION
This is to allow for the received notifications to offer the user sets of actions that are appropriate with the respective category.
