### PR TITLE
Mark notifications with "mutable-content" and add .DS_Store files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /old-judge/
 HotelAppCodeBurrow.pem
 node_modules/
+.DS_Store

--- a/app/Controllers/MainController.php
+++ b/app/Controllers/MainController.php
@@ -206,6 +206,7 @@ class MainController extends Controller
             'badge' => 1,
             'sound' => 'default',
             'link_url' => 'http://www.w3schools.com/w3css/w3css_colors.asp',
+            'mutable-content' => 1,
         );
 
         $rtn = $push->sendMessage($params);


### PR DESCRIPTION
Mark notifications with "mutable-content" to signify that the client iOS device needs to modify the
notification’s content or download content before displaying the
notification.

DS_Store files are used by MacOS to store custom attributes of its containing folder, such as the position of icons or the choice of a background image. Git doesn’t have to keep track of such files.
